### PR TITLE
refactor: Set the background image earlier

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>New Tab - Stellar Photos</title>
+  <script src="js/set-image.js"></script>
   <link rel="stylesheet" href="css/main.css">
 </head>
 <body>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -14,12 +14,13 @@ alertify.defaults = {
   },
 };
 
+performance.mark('wastedTimeEnd');
+performance.measure('wastedTime', 'wastedTimeBegin', 'wastedTimeEnd');
+console.log('Time wasted:', performance.getEntriesByName('wastedTime')[0].duration);
+
 chrome.storage.local.get('nextImage', (result) => {
   const { nextImage } = result;
   if (nextImage) {
-    const body = document.querySelector('body');
-    body.style.backgroundImage = `url(${nextImage.base64})`;
-
     const controls = document.querySelector('.controls');
     controls.insertAdjacentHTML('beforeend', `
       <div class="popover options-popover">

--- a/src/js/set-image.js
+++ b/src/js/set-image.js
@@ -1,0 +1,9 @@
+chrome.storage.local.get('nextImage', (result) => {
+    const { nextImage } = result;
+    if (nextImage) {
+      const body = document.querySelector('body');
+      body.style.backgroundImage = `url(${nextImage.base64})`;
+    }
+});
+
+performance.mark('wastedTimeBegin');


### PR DESCRIPTION
This PR moves the logic of setting the background earlier in the script execution, before the JS (66kB) is parsed, loaded into memory and executed. 

On my machine, the image is set ~70ms earlier on Chrome 61 and ~230ms earlier on Firefox 58. I've left the benchmarking code to allow replication - will remove it if this PR is accepted.