### PR TITLE
refactor: Lazy-load CSS, font and JS

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,8 +5,47 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>New Tab - Stellar Photos</title>
+  <style>
+    /* Inline the critical CSS needed to display the background image */
+    body {
+      height: 100%;
+      background-color: #111;
+      background-size: cover;
+      background-position: 50%;
+      background-attachment: fixed;
+    }
+
+    .hidden {
+      display: none;
+    }
+
+    .loader {
+      width: 300px;
+    }
+
+    @keyframes fadeIn {
+      0% {
+        opacity: 0.5;
+      }
+
+      100% {
+        opacity: 0;
+      }
+    }
+
+    .s-overlay {
+      position: fixed;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      animation: fadeIn 1s ease;
+      background-color: #111;
+      opacity: 0;
+      z-index: -1000;
+    }
+  </style>
   <script src="js/set-image.js"></script>
-  <link rel="stylesheet" href="css/main.css">
 </head>
 <body>
 
@@ -16,7 +55,7 @@
 
   <main class="s-main">
 
-    <button id="searchButton-open" class="searchButton searchButton-open" aria-label="Open search form" style="position:fixed; width: 40px; height: 40px; top: 20px; right: 20px;">
+    <button id="searchButton-open" class="searchButton searchButton-open hidden" aria-label="Open search form" style="position:fixed; width: 40px; height: 40px; top: 20px; right: 20px;">
       <svg class="icon icon--search">
         <use xlink:href="#icon-search"></use>
       </svg>
@@ -130,7 +169,5 @@
 
     </defs>
   </svg>
-  
-  <script src="js/index.js"></script>
 </body>
 </html>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -245,6 +245,7 @@ const loadMore = document.querySelector('.moreResults-button');
 loadMore.addEventListener('click', () => searchPhotos(state.searchKey, state.page));
 
 const searchButtonOpen = document.getElementById('searchButton-open');
+searchButtonOpen.classList.remove('hidden');
 searchButtonOpen.addEventListener('click', openSearch);
 
 const searchButtonClose = document.getElementById('searchButton-close');

--- a/src/js/set-image.js
+++ b/src/js/set-image.js
@@ -6,3 +6,34 @@ chrome.storage.local.get('nextImage', (result) => {
   }
 });
 
+const loadCss = url => new Promise((resolve, reject) => {
+    const link = document.createElement("link");
+    link.type = "text/css";
+    link.rel = "stylesheet";
+    link.href = url;
+    link.onload = resolve;
+    link.onerror = reject;
+    document.getElementsByTagName("head")[0].appendChild(link);
+});
+
+const loadJs = url => new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = url;
+    script.onload = resolve;
+    script.onerror = reject;
+    document.getElementsByTagName("head")[0].appendChild(script);
+});
+
+const loadControls = () => {
+  document.removeEventListener('mousemove', loadControls);
+  document.removeEventListener('focus', loadControls);
+
+  // CSS first to avoid flash of unstyled content
+  loadCss('css/main.css')
+    .then(() => loadJs('js/index.js'))
+    .catch(error => console.log(error));
+};
+
+document.addEventListener('mousemove', loadControls);
+document.addEventListener('focus', loadControls);
+

--- a/src/sass/base/_base.sass
+++ b/src/sass/base/_base.sass
@@ -16,30 +16,7 @@ html
   padding: 0
 
 body
-  height: 100%
   font-family: $code-font-stack
-  background-color: #111
-  background-size: cover
-  background-position: 50%
-  background-attachment: fixed
-
-.s-overlay
-  position: fixed
-  top: 0
-  bottom: 0
-  left: 0
-  right: 0
-  animation: fadeIn 1s ease
-  background-color: #111
-  opacity: 0
-  z-index: -1000
-
-@keyframes fadeIn
-  0%
-    opacity: 0.5
-
-  100%
-    opacity: 0
 
 .s-container
   margin: 0 auto

--- a/src/sass/modules/_loader.sass
+++ b/src/sass/modules/_loader.sass
@@ -3,7 +3,6 @@
   position: fixed
   top: 0
   right: 0
-  width: 300px
   height: 300px
   background: #2980B9
   transition: transform 0.3s


### PR DESCRIPTION
Reduced the number of requests from 26 to 3 (`index.js`, `set-image.js` and the image). The other 23 are loaded upon user interaction (the document receives focus or `mousemove` is triggered). Critical CSS is inlined to avoid fetching and parsing the entire bundle.

The CSS and JS are loaded manually via script injection - not ideal but I wanted to avoid installing more babel plugins for dynamic import.