### PR TITLE
refactor: Optimize animations (translate instead of height)

### DIFF
--- a/src/sass/partials/_footer.sass
+++ b/src/sass/partials/_footer.sass
@@ -10,10 +10,10 @@
   background-color: rgba(0, 0, 0, 0.5)
   color: $white
   z-index: 200
-  transition: all 0.5s
+  transition: transform 0.5s
 
   &.history-open
-    bottom: 150px
+    transform: translateY(-150px)
 
   svg
     width: 20px

--- a/src/sass/partials/_history.sass
+++ b/src/sass/partials/_history.sass
@@ -1,5 +1,6 @@
 .s-history
-  height: 0
+  height: 150px
+  transform: translateY(150px)
   width: 100%
   overflow: hidden
   bottom: 0
@@ -7,13 +8,13 @@
   right: 0
   background-color: #111
   position: fixed
-  transition: all 0.5s
+  transition: transform 0.5s
   z-index: 1000
   list-style: none
   display: flex
 
   &.open
-    height: 150px
+    transform: translateY(0)
 
   .s-photo
     width: 10%


### PR DESCRIPTION
The animation was a bit janky, so instead of animating the height/position we use `translate`, which is much cheaper (see https://www.html5rocks.com/en/tutorials/speed/high-performance-animations/).