### PR TITLE
fix: Send load-data command from set-image

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -264,5 +264,3 @@ document.addEventListener('click', (node) => {
   const popover = document.querySelectorAll('.popover .popover-content');
   popover.forEach(e => e.classList.remove('popover-content--is-visible'));
 });
-
-chrome.runtime.sendMessage({ command: 'load-data' });

--- a/src/js/set-image.js
+++ b/src/js/set-image.js
@@ -6,6 +6,8 @@ chrome.storage.local.get('nextImage', (result) => {
   }
 });
 
+chrome.runtime.sendMessage({ command: 'load-data' });
+
 const loadCss = url => new Promise((resolve, reject) => {
   const link = document.createElement('link');
   link.type = 'text/css';


### PR DESCRIPTION
I kept getting the same image over and over - because I usually open the tab via Ctrl-T and don't interact with the page, thus not loading the main bundle which fetches the next image.